### PR TITLE
Add Dropdown menu & dropdown menu link animations.

### DIFF
--- a/css/site.css
+++ b/css/site.css
@@ -46,11 +46,12 @@ body {
 .dropdown:hover .dropdown-content {
     display: block;
 }
-
+/*
 .dropdown-content a:hover {
   background-color: #ECB365;
   color: #04293A;
 }
+*/
 
 .header {
     color: gray;

--- a/css/site.css
+++ b/css/site.css
@@ -22,6 +22,36 @@ body {
     padding: 10px;
 }
 
+.dropdown {
+    display: inline-block;
+}
+
+.dropdown a {
+    cursor: pointer;
+}
+
+.dropdown-content {
+    margin-top: 10px; /* Hardcoded this once, as styling the dropdown would affect the whole navbar */
+    display: none;
+    position: absolute;
+    background-color: #04293A;
+}
+
+.dropdown-content a {
+  text-decoration: none;
+  display: block;
+  text-align: left;
+}
+
+.dropdown:hover .dropdown-content {
+    display: block;
+}
+
+.dropdown-content a:hover {
+  background-color: #ECB365;
+  color: #04293A;
+}
+
 .header {
     color: gray;
     font-size: 20px;

--- a/index.html
+++ b/index.html
@@ -16,9 +16,16 @@
 			<a href="https://docs.libertybans.org/#/">Wiki</a>
 			<a href="https://discord.com/invite/3C4qeG8XhE">Support</a>
 			<a href="https://github.com/A248/LibertyBans/">GitHub</a>
-			<a href="https://ci.hahota.net/job/LibertyBans/">Jenkins</a>
-			<a href="https://modrinth.com/plugin/libertybans/">Modrinth</a>
-			<a href="https://www.spigotmc.org/resources/libertybans.81063/">SpigotMC</a>
+
+			<div class="dropdown">
+				<a>Downloads</a>
+				<div class="dropdown-content">
+					<a href="https://ci.hahota.net/job/LibertyBans/">Jenkins</a>
+					<a href="https://modrinth.com/plugin/libertybans/">Modrinth</a>
+					<a href="https://www.spigotmc.org/resources/libertybans.81063/">SpigotMC</a>
+				</div>
+			</div>
+
 			<a href="https://gist.github.com/KoxSosen/774b0ba0e813649d6b62e2e21e188c00/">IRC</a>
 		</div>
 		<div class="header">


### PR DESCRIPTION
This pull request adds a new navigation bar entry called "Downloads", which has a dropdown menu, which contains all of the platforms we publish to. In the future, new entries to this dropdown can be added.

There are some things that I don't like about this implementation:
- It has a hardcoded `margin-top` value of `10` for the dropdown menu. This is will make make the dropdown menu appear exactly below the navigation bar, as in reality, the Downloads div doesn't consume all the vertical "space" of  the navigation bar, and would result in something like this: 
![image](https://user-images.githubusercontent.com/67807644/189954490-f1a023f7-d370-4583-8d47-9d7badce9cde.png)
- The implementation of the dropdown menu's link selection animation isn't consistent. Currently, we only apply it to the dropdown menu links, but not the navigation bar. I think we should either apply it to both, or neither. 

Edit: I disabled animations by default. If you are interested in checking out how they look, please clone the dropdown branch, and then uncomment the multi-line comment [here](https://github.com/KoxSosen/lbsite/blob/dropdown/css/site.css#L49), or view the attached screenshot.
![image](https://user-images.githubusercontent.com/67807644/189962928-a17b9fb7-3ad6-43e7-bcb5-21786e4c00e9.png)


Moreover, I would like to thank @A248 for the idea of this feature.